### PR TITLE
when service account is used then skip terminal validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 > It utilizes google drive api v3 and google OAuth2.0 to generate access tokens and to authorize application for uploading files/folders to your google drive.
 
 - Minimal
+- Two modes of authentication
+  - Oauth credentials
+  - Service account credentials
 - Upload or Update files/folders
 - Recursive folder uploading
 - Sync your folders
@@ -50,6 +53,7 @@
   - [Updation](#updation)
 - [Usage](#usage)
   - [Generating Oauth Credentials](#generating-oauth-credentials)
+  - [Generating service account credentials](#generating-service-account-credentials)
   - [Enable Drive API](#enable-drive-api)
   - [First Run](#first-run)
   - [Config file](#config)
@@ -116,6 +120,9 @@ This repo contains two types of scripts, posix compatible and bash compatible.
 | mktemp           | To generate temporary files ( optional )               |
 | sleep            | Self explanatory                                       |
 | ps               | To manage different processes                          |
+| openssl          | For service account usage ( optional )                 |
+
+Note: If openssl if not installed, then `-sa | --service-account` flag won't work, but script will install successfully.
 
 <strong>If BASH is not available or BASH is available but version is less tham 4.x, then below programs are also required:</strong>
 
@@ -296,9 +303,13 @@ There are two methods:
 
 ## Usage
 
-First, we need to obtain our oauth credentials, here's how to do it:
+First, we have to authenticate.
+
+There are two ways to authenticate, oauth credentials or service accounts. Use any one.
 
 ### Generating Oauth Credentials
+
+To obtain oauth credentials, follow below steps:
 
 - Follow [Enable Drive API](#enable-drive-api) section.
 - Open [google console](https://console.developers.google.com/).
@@ -310,6 +321,24 @@ First, we need to obtain our oauth credentials, here's how to do it:
 - Download your credentials.json by clicking on the download button.
 
 Now, we have obtained our credentials, move to the [First run](#first-run) section to use those credentials:
+
+### Generating service account credentials
+
+To obtain service account credentials, follow below steps:
+
+- Follow [Enable Drive API](#enable-drive-api) section.
+- Open [google console](https://console.developers.google.com/).
+- Click on "Credentials".
+- Click "Create credentials" and select "Service account".
+- Provide name for service account and click on create. If successful, it should be on step 2.
+- Now tap on role and select owner. Click on continue. If successful, it should be on step 3.
+- Click on done.
+- Now click on manage service accounts.
+- Click on the service account name you created.
+- Click on add key, then tap on create new key. Choose json and tap on create.
+- If successful, a file should download in the .json format.
+
+Now, we have obtained our service account json, move to the [First run](#first-run) section to use those credentials:
 
 ### Enable Drive API
 
@@ -331,7 +360,13 @@ By this, a side bar is opened. At there, select "API & Services" -> "Library". A
 
 [Go back to oauth credentials setup](#generating-oauth-credentials)
 
+[Go back to service account generation](#generating-service-account-credentials)
+
 ### First Run
+
+On first run, there are two possibilities, either using oauth credentials or service account credentials.
+
+#### For Oauth
 
 On first run, the script asks for all the required credentials, which we have obtained in the previous section.
 
@@ -339,20 +374,33 @@ Execute the script: `gupload filename`
 
 Now, it will ask for following credentials:
 
-**Client ID:** Copy and paste from credentials.json
+-   **Client ID:** Copy and paste from credentials.json
 
-**Client Secret:** Copy and paste from credentials.json
+-   **Client Secret:** Copy and paste from credentials.json
 
-**Refresh Token:** If you have previously generated a refresh token authenticated to your account, then enter it, otherwise leave blank.
-If you don't have refresh token, script outputs a URL on the terminal script, open that url in a web browser and tap on allow. Copy the code and paste in the terminal.
+-   **Refresh Token:** If you have previously generated a refresh token authenticated to your account, then enter it, otherwise leave blank.
 
-**Root Folder:** Gdrive folder url/id from your account which you want to set as root folder. You can leave it blank and it takes `root` folder as default.
+    If you don't have refresh token, script outputs a URL on the terminal script, open that url in a web browser and tap on allow. Copy the code and paste in the terminal.
+
+-   **Root Folder:** Gdrive folder url/id from your account which you want to set as root folder. You can leave it blank and it takes `root` folder as default.
 
 If everything went fine, all the required credentials have been set, read the next section on how to upload a file/folder.
 
+#### For service accounts
+
+For using service account, use `-sa | --service-account` flag.
+
+Execute the script: `gupload filename -sa "service account json file path"`
+
+Note: For service accounts it is necessary to use the `-sa | --service-account` flag everytime.
+
+For more info, see `-sa | --service-account` flag in [Upload Script Custom Flags](#upload-script-custom-flags).
+
 ### Config
 
-After first run, the credentials are saved in config file. By default, the config file is `${HOME}/.googledrive.conf`.
+After first run, if oauth credentials are used, then credentials are saved in config file, otherwise for service accounts it is necessary to use the `-sa | --service-account` flag everytime.
+
+By default, the config file is `${HOME}/.googledrive.conf`.
 
 To change the default config file or use a different one temporarily, see `-z / --config` custom in [Upload Script Custom Flags](#upload-script-custom-flags).
 
@@ -409,6 +457,14 @@ Apart from basic usage, this script provides many flags for custom usecases, lik
 ### Upload Script Custom Flags
 
 These are the custom flags that are currently implemented:
+
+-   <strong>--sa | --service-accounts 'service account json file path'</strong>
+
+    Use a service account. Should be in proper json format.
+
+    To generate service accounts, see [service account generation](#generating-service-account-credentials) section.
+
+    ---
 
 -   <strong>-z | --config</strong>
 

--- a/bash/common-utils.bash
+++ b/bash/common-utils.bash
@@ -324,7 +324,7 @@ _update_config() {
     chmod u+w "${config_path}"
     printf "%s\n%s\n" "$(grep -v -e "^$" -e "^${value_name}=" "${config_path}" || :)" \
         "${value_name}=\"${value}\"" >| "${config_path}"
-    chmod u-w+r "${config_path}"
+    chmod a-w-r-x,u+r "${config_path}"
 }
 
 ###################################################

--- a/bash/drive-utils.bash
+++ b/bash/drive-utils.bash
@@ -186,11 +186,22 @@ _extract_id() {
 # Result: Update access_token and expiry else print error
 ###################################################
 _get_access_token_and_update() {
-    RESPONSE="${1:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+    case "${1:?Error: sa or normal}" in
+        normal)
+            RESPONSE="${2:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+            ;;
+        sa)
+            declare assertion_data="${2:?2lError: Missing assertion data.}"
+            RESPONSE="$(curl --compressed -s --data "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${assertion_data}" "${TOKEN_URL}")" || :
+            # sa token jsons are not pretty printed
+            RESPONSE="${RESPONSE//,\"/$'\n'\"}"
+            ;;
+    esac
+
     if ACCESS_TOKEN="$(_json_value access_token 1 1 <<< "${RESPONSE}")"; then
         ACCESS_TOKEN_EXPIRY="$(($(printf "%(%s)T\\n" "-1") + $(_json_value expires_in 1 1 <<< "${RESPONSE}") - 1))"
-        _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-        _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+        _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
+        _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
     else
         "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
         printf "%s\n" "${RESPONSE}" 1>&2

--- a/bash/drive-utils.bash
+++ b/bash/drive-utils.bash
@@ -202,6 +202,9 @@ _get_access_token_and_update() {
         ACCESS_TOKEN_EXPIRY="$(($(printf "%(%s)T\\n" "-1") + $(_json_value expires_in 1 1 <<< "${RESPONSE}") - 1))"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+        
+        _update_config "ACCESS_TOKEN" "${ACCESS_TOKEN}" "${TMPFILE}_ACCESS_TOKEN"
+        _update_config "ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${TMPFILE}_ACCESS_TOKEN"
     else
         "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
         printf "%s\n" "${RESPONSE}" 1>&2

--- a/bash/google-oauth2.bash
+++ b/bash/google-oauth2.bash
@@ -113,7 +113,7 @@ if [[ ${1} = create ]]; then
     _clear_line 1 1>&2
 
     REFRESH_TOKEN="$(_json_value refresh_token 1 1 <<< "${RESPONSE}" || :)"
-    if _get_access_token_and_update "${RESPONSE}"; then
+    if _get_access_token_and_update normal "${RESPONSE}"; then
         _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"
         printf "Access Token: %s\n" "${ACCESS_TOKEN}"
         printf "Refresh Token: %s\n" "${REFRESH_TOKEN}"
@@ -123,7 +123,7 @@ if [[ ${1} = create ]]; then
 elif [[ ${1} = refresh ]]; then
     if [[ -n ${REFRESH_TOKEN} ]]; then
         _print_center "justify" "Required credentials set." "="
-        { _get_access_token_and_update && _clear_line 1; } || return 1
+        { _get_access_token_and_update normal && _clear_line 1; } || return 1
         printf "Access Token: %s\n" "${ACCESS_TOKEN}"
     else
         "${QUIET:-_print_center}" "normal" "Refresh Token not set" ", use ${0##*/} create to generate one." "="

--- a/bash/release/gsync
+++ b/bash/release/gsync
@@ -325,7 +325,7 @@ _update_config() {
     chmod u+w "${config_path}"
     printf "%s\n%s\n" "$(grep -v -e "^$" -e "^${value_name}=" "${config_path}" || :)" \
         "${value_name}=\"${value}\"" >| "${config_path}"
-    chmod u-w+r "${config_path}"
+    chmod a-w-r-x,u+r "${config_path}"
 }
 
 ###################################################

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -539,11 +539,22 @@ _extract_id() {
 # Result: Update access_token and expiry else print error
 ###################################################
 _get_access_token_and_update() {
-    RESPONSE="${1:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+    case "${1:?Error: sa or normal}" in
+        normal)
+            RESPONSE="${2:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+            ;;
+        sa)
+            declare assertion_data="${2:?2lError: Missing assertion data.}"
+            RESPONSE="$(curl --compressed -s --data "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${assertion_data}" "${TOKEN_URL}")" || :
+            # sa token jsons are not pretty printed
+            RESPONSE="${RESPONSE//,\"/$'\n'\"}"
+            ;;
+    esac
+
     if ACCESS_TOKEN="$(_json_value access_token 1 1 <<< "${RESPONSE}")"; then
         ACCESS_TOKEN_EXPIRY="$(($(printf "%(%s)T\\n" "-1") + $(_json_value expires_in 1 1 <<< "${RESPONSE}") - 1))"
-        _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-        _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+        _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
+        _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
     else
         "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
         printf "%s\n" "${RESPONSE}" 1>&2
@@ -826,6 +837,49 @@ _error_logging_upload() {
 }
 
 ###################################################
+# Generate rs256 jwt just with cli commands and shell
+# Specifically for gdrive service accounts usage
+# Globals: 1
+#  SCOPE ( optional )
+# Arguments: 2
+#   ${1} = service account json file
+#   ${2} = SCOPE for gdrive
+# Result: print jwt
+# Refrences:
+#   https://stackoverflow.com/questions/46657001/how-do-you-create-an-rs256-jwt-assertion-with-bash-shell-scripting
+#   Inspired by implementation by Will Haley at:
+#     http://willhaley.com/blog/generate-jwt-with-bash/
+###################################################
+_generate_jwt() {
+    declare json_file="${1:?Error: Give service json file name}" \
+        scope="${2:-${SCOPE:?Error: Missing scope}}" \
+        aud="https://oauth2.googleapis.com/token" \
+        header='{"alg":"RS256","typ":"JWT"}' \
+        algo="256" payload_data iss exp iat rsa_secret signed_content sign
+
+    if iss="$(_json_value client_email 1 1 < "${json_file}")" &&
+        rsa_secret="$(_json_value private_key 1 1 < "${json_file}")"; then
+        rsa_secret="$(printf "%b\n" "${rsa_secret}")"
+    else
+        "${QUIET:-_print_center}" 'normal' "Error: Invalid service account file." "=" && return 1
+    fi
+
+    iat="$(printf "%(%s)T\\n" "-1")" exp="$((iat + 3400))"
+
+    b64enc() { : "$(openssl enc -base64 -A)" && : "${_//+/-}" && : "${_//\//_}" && printf "%s\n" "${_//=/}"; }
+
+    payload_data='{"iss":"'${iss}'","scope":"'${scope}'","aud":"'${aud}'","exp":'${exp}',"iat":'${iat}'}'
+
+    {
+        signed_content="$(b64enc <<< "${header}").$(b64enc <<< "${payload_data}")"
+        sign="$(printf %s "${signed_content}" | openssl dgst -binary -sha"${algo}" -sign <(printf '%s\n' "${rsa_secret}") | b64enc)"
+    } || return 1
+
+    printf '%s.%s\n' "${signed_content}" "${sign}"
+    return 0
+}
+
+###################################################
 # A small function to get rootdir id for files in sub folder uploads
 # Globals: 1 variable, 1 function
 #   Variables - DIRIDS
@@ -944,6 +998,7 @@ Usage:\n ${0##*/} [options.. ] <filename> <foldername>\n
 Foldername argument is optional. If not provided, the file will be uploaded to preconfigured google drive.\n
 File name argument is optional if create directory option is used.\n
 Options:\n
+  -sa | --service-accounts 'service account json file path' - Use a bot service account. Should be in proper json format.\n
   -c | -C | --create-dir <foldername> - option to create directory. Will provide folder id. Can be used to provide input folder, see README.\n
   -r | --root-dir <google_folderid> or <google_folder_url> - google folder ID/URL to which the file/directory is going to upload.
       If you want to change the default value, then use this format, -r/--root-dir default=root_folder_id/root_folder_url\n
@@ -1046,14 +1101,15 @@ _setup_arguments() {
     # De-initialize if any variables set already.
     unset FIRST_INPUT FOLDER_INPUT FOLDERNAME LOCAL_INPUT_ARRAY ID_INPUT_ARRAY
     unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_EMAIL OVERWRITE SKIP_DUPLICATES SKIP_SUBDIRS ROOTDIR QUIET
-    unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY
+    unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY OPENSSL_ERROR
     CURL_PROGRESS="-s" EXTRA_LOG=":" CURL_PROGRESS_EXTRA="-s"
     INFO_PATH="${HOME}/.google-drive-upload" CONFIG_INFO="${INFO_PATH}/google-drive-upload.configpath"
     [[ -f ${CONFIG_INFO} ]] && . "${CONFIG_INFO}"
     CONFIG="${CONFIG:-${HOME}/.googledrive.conf}"
 
     # Configuration variables # Remote gDrive variables
-    unset ROOT_FOLDER CLIENT_ID CLIENT_SECRET REFRESH_TOKEN ACCESS_TOKEN
+    unset ROOT_FOLDER CLIENT_ID CLIENT_SECRET REFRESH_TOKEN ACCESS_TOKEN \
+        SERVICE_ACCOUNT SERVICE_ACCOUNT_ACCESS_TOKEN SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY
     API_URL="https://www.googleapis.com"
     API_VERSION="v3"
     SCOPE="${API_URL}/auth/drive"
@@ -1080,6 +1136,11 @@ _setup_arguments() {
             -h | --help) _usage ;;
             -D | --debug) DEBUG="true" && export DEBUG ;;
             --info) _version_info ;;
+            -sa | --service-account)
+                _check_longoptions "${1}" "${2}"
+                SERVICE_ACCOUNT_FILE="${2}" && shift
+                ! [[ -f ${SERVICE_ACCOUNT_FILE} ]] && printf "%s\n" "Error: Service account json file exist ( ${SERVICE_ACCOUNT_FILE} )." 1>&2 && exit 1
+                ;;
             -c | -C | --create-dir)
                 _check_longoptions "${1}" "${2}"
                 FOLDERNAME="${2}" && shift
@@ -1235,107 +1296,134 @@ _check_credentials() {
         printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
     }
 
-    # Following https://developers.google.com/identity/protocols/oauth2#size
-    CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
-    CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
-    REFRESH_TOKEN_REGEX='[0-9]//[0-9A-Za-z_-]+'     # 512 bytes
-    ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+'       # 2048 bytes
-    AUTHORIZATION_CODE_REGEX='[0-9]/[0-9A-Za-z_-]+' # 256 bytes
+    ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+' # 2048 bytes
 
-    until [[ -n ${CLIENT_ID} && -n ${CLIENT_ID_VALID} ]]; do
-        [[ -n ${CLIENT_ID} ]] && {
-            if [[ ${CLIENT_ID} =~ ${CLIENT_ID_REGEX} ]]; then
-                [[ -n ${client_id} ]] && _update_config CLIENT_ID "${CLIENT_ID}" "${CONFIG}"
-                CLIENT_ID_VALID="true" && continue
-            else
-                { [[ -n ${client_id} ]] && message="- Try again"; } || message="in config ( ${CONFIG} )"
-                "${QUIET:-_print_center}" "normal" " Invalid Client ID ${message} " "-" && unset CLIENT_ID client_id
-            fi
+    if [[ -z ${SERVICE_ACCOUNT_FILE} ]]; then
+        # Following https://developers.google.com/identity/protocols/oauth2#size
+        CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
+        CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
+        REFRESH_TOKEN_REGEX='[0-9]//[0-9A-Za-z_-]+'     # 512 bytes
+        AUTHORIZATION_CODE_REGEX='[0-9]/[0-9A-Za-z_-]+' # 256 bytes
+
+        until [[ -n ${CLIENT_ID} && -n ${CLIENT_ID_VALID} ]]; do
+            [[ -n ${CLIENT_ID} ]] && {
+                if [[ ${CLIENT_ID} =~ ${CLIENT_ID_REGEX} ]]; then
+                    [[ -n ${client_id} ]] && _update_config CLIENT_ID "${CLIENT_ID}" "${CONFIG}"
+                    CLIENT_ID_VALID="true" && continue
+                else
+                    { [[ -n ${client_id} ]] && message="- Try again"; } || message="in config ( ${CONFIG} )"
+                    "${QUIET:-_print_center}" "normal" " Invalid Client ID ${message} " "-" && unset CLIENT_ID client_id
+                fi
+            }
+            [[ -z ${client_id} ]] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client ID " "-"
+            [[ -n ${client_id} ]] && _clear_line 1
+            printf -- "-> "
+            read -r CLIENT_ID && client_id=1
+        done
+
+        until [[ -n ${CLIENT_SECRET} && -n ${CLIENT_SECRET_VALID} ]]; do
+            [[ -n ${CLIENT_SECRET} ]] && {
+                if [[ ${CLIENT_SECRET} =~ ${CLIENT_SECRET_REGEX} ]]; then
+                    [[ -n ${client_secret} ]] && _update_config CLIENT_SECRET "${CLIENT_SECRET}" "${CONFIG}"
+                    CLIENT_SECRET_VALID="true" && continue
+                else
+                    { [[ -n ${client_secret} ]] && message="- Try again"; } || message="in config ( ${CONFIG} )"
+                    "${QUIET:-_print_center}" "normal" " Invalid Client Secret ${message} " "-" && unset CLIENT_SECRET client_secret
+                fi
+            }
+            [[ -z ${client_secret} ]] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client Secret " "-"
+            [[ -n ${client_secret} ]] && _clear_line 1
+            printf -- "-> "
+            read -r CLIENT_SECRET && client_secret=1
+        done
+
+        [[ -n ${REFRESH_TOKEN} ]] && {
+            ! [[ ${REFRESH_TOKEN} =~ ${REFRESH_TOKEN_REGEX} ]] &&
+                "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token in config file, follow below steps.. " "-" && unset REFRESH_TOKEN
         }
-        [[ -z ${client_id} ]] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client ID " "-"
-        [[ -n ${client_id} ]] && _clear_line 1
-        printf -- "-> "
-        read -r CLIENT_ID && client_id=1
-    done
-
-    until [[ -n ${CLIENT_SECRET} && -n ${CLIENT_SECRET_VALID} ]]; do
-        [[ -n ${CLIENT_SECRET} ]] && {
-            if [[ ${CLIENT_SECRET} =~ ${CLIENT_SECRET_REGEX} ]]; then
-                [[ -n ${client_secret} ]] && _update_config CLIENT_SECRET "${CLIENT_SECRET}" "${CONFIG}"
-                CLIENT_SECRET_VALID="true" && continue
-            else
-                { [[ -n ${client_secret} ]] && message="- Try again"; } || message="in config ( ${CONFIG} )"
-                "${QUIET:-_print_center}" "normal" " Invalid Client Secret ${message} " "-" && unset CLIENT_SECRET client_secret
-            fi
-        }
-        [[ -z ${client_secret} ]] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client Secret " "-"
-        [[ -n ${client_secret} ]] && _clear_line 1
-        printf -- "-> "
-        read -r CLIENT_SECRET && client_secret=1
-    done
-
-    [[ -n ${REFRESH_TOKEN} ]] && {
-        ! [[ ${REFRESH_TOKEN} =~ ${REFRESH_TOKEN_REGEX} ]] &&
-            "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token in config file, follow below steps.. " "-" && unset REFRESH_TOKEN
-    }
-
-    [[ -z ${REFRESH_TOKEN} ]] && {
-        printf "\n" && "${QUIET:-_print_center}" "normal" "If you have a refresh token generated, then type the token, else leave blank and press return key.." " "
-        printf "\n" && "${QUIET:-_print_center}" "normal" " Refresh Token " "-" && printf -- "-> "
-        read -r REFRESH_TOKEN
-        if [[ -n ${REFRESH_TOKEN} ]]; then
-            "${QUIET:-_print_center}" "normal" " Checking refresh token.. " "-"
-            if [[ ${REFRESH_TOKEN} =~ ${REFRESH_TOKEN_REGEX} ]]; then
-                { _get_access_token_and_update && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || check_error=true
-            else
-                check_error=true
-            fi
-            [[ -n ${check_error} ]] && "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token given, follow below steps to generate.. " "-" && unset REFRESH_TOKEN
-        else
-            "${QUIET:-_print_center}" "normal" " No Refresh token given, follow below steps to generate.. " "-"
-        fi
 
         [[ -z ${REFRESH_TOKEN} ]] && {
-            printf "\n" && "${QUIET:-_print_center}" "normal" "Visit the below URL, tap on allow and then enter the code obtained" " "
-            URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code&prompt=consent"
-            printf "\n%s\n" "${URL}"
-            until [[ -n ${AUTHORIZATION_CODE} && -n ${AUTHORIZATION_CODE_VALID} ]]; do
-                [[ -n ${AUTHORIZATION_CODE} ]] && {
-                    if [[ ${AUTHORIZATION_CODE} =~ ${AUTHORIZATION_CODE_REGEX} ]]; then
-                        AUTHORIZATION_CODE_VALID="true" && continue
-                    else
-                        "${QUIET:-_print_center}" "normal" " Invalid CODE given, try again.. " "-" && unset AUTHORIZATION_CODE authorization_code
-                    fi
-                }
-                { [[ -z ${authorization_code} ]] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter the authorization code " "-"; } || _clear_line 1
-                printf -- "-> "
-                read -r AUTHORIZATION_CODE && authorization_code=1
-            done
-            RESPONSE="$(curl --compressed "${CURL_PROGRESS}" -X POST \
-                --data "code=${AUTHORIZATION_CODE}&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&redirect_uri=${REDIRECT_URI}&grant_type=authorization_code" "${TOKEN_URL}")" || :
-            _clear_line 1 1>&2
+            printf "\n" && "${QUIET:-_print_center}" "normal" "If you have a refresh token generated, then type the token, else leave blank and press return key.." " "
+            printf "\n" && "${QUIET:-_print_center}" "normal" " Refresh Token " "-" && printf -- "-> "
+            read -r REFRESH_TOKEN
+            if [[ -n ${REFRESH_TOKEN} ]]; then
+                "${QUIET:-_print_center}" "normal" " Checking refresh token.. " "-"
+                if [[ ${REFRESH_TOKEN} =~ ${REFRESH_TOKEN_REGEX} ]]; then
+                    { _get_access_token_and_update normal && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || check_error=true
+                else
+                    check_error=true
+                fi
+                [[ -n ${check_error} ]] && "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token given, follow below steps to generate.. " "-" && unset REFRESH_TOKEN
+            else
+                "${QUIET:-_print_center}" "normal" " No Refresh token given, follow below steps to generate.. " "-"
+            fi
 
-            REFRESH_TOKEN="$(_json_value refresh_token 1 1 <<< "${RESPONSE}" || :)"
-            { _get_access_token_and_update "${RESPONSE}" && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || return 1
+            [[ -z ${REFRESH_TOKEN} ]] && {
+                printf "\n" && "${QUIET:-_print_center}" "normal" "Visit the below URL, tap on allow and then enter the code obtained" " "
+                URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code&prompt=consent"
+                printf "\n%s\n" "${URL}"
+                until [[ -n ${AUTHORIZATION_CODE} && -n ${AUTHORIZATION_CODE_VALID} ]]; do
+                    [[ -n ${AUTHORIZATION_CODE} ]] && {
+                        if [[ ${AUTHORIZATION_CODE} =~ ${AUTHORIZATION_CODE_REGEX} ]]; then
+                            AUTHORIZATION_CODE_VALID="true" && continue
+                        else
+                            "${QUIET:-_print_center}" "normal" " Invalid CODE given, try again.. " "-" && unset AUTHORIZATION_CODE authorization_code
+                        fi
+                    }
+                    { [[ -z ${authorization_code} ]] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter the authorization code " "-"; } || _clear_line 1
+                    printf -- "-> "
+                    read -r AUTHORIZATION_CODE && authorization_code=1
+                done
+                RESPONSE="$(curl --compressed "${CURL_PROGRESS}" -X POST \
+                    --data "code=${AUTHORIZATION_CODE}&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&redirect_uri=${REDIRECT_URI}&grant_type=authorization_code" "${TOKEN_URL}")" || :
+                _clear_line 1 1>&2
+
+                REFRESH_TOKEN="$(_json_value refresh_token 1 1 <<< "${RESPONSE}" || :)"
+                { _get_access_token_and_update normal "${RESPONSE}" && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || return 1
+            }
+            printf "\n"
         }
-        printf "\n"
-    }
+        [[ -z ${ACCESS_TOKEN} || ${ACCESS_TOKEN_EXPIRY:-0} -lt "$(printf "%(%s)T\\n" "-1")" ]] || ! [[ ${ACCESS_TOKEN} =~ ${ACCESS_TOKEN_REGEX} ]] &&
+            { _get_access_token_and_update normal || return 1; }
+        printf "%b\n" "ACCESS_TOKEN=\"${ACCESS_TOKEN}\"\nACCESS_TOKEN_EXPIRY=\"${ACCESS_TOKEN_EXPIRY}\"" >| "${TMPFILE}_ACCESS_TOKEN"
+    else
+        command -v openssl 2>| /dev/null 1>&2 ||
+            { "${QUIET:-_print_center}" 'normal' "Error: openssl not installed, install openssl to use '-sa | --service-account' flag." "=" 1>&2 && return 1; }
 
-    [[ -z ${ACCESS_TOKEN} || ${ACCESS_TOKEN_EXPIRY:-0} -lt "$(printf "%(%s)T\\n" "-1")" ]] || ! [[ ${ACCESS_TOKEN} =~ ${ACCESS_TOKEN_REGEX} ]] &&
-        { _get_access_token_and_update || return 1; }
-    printf "%b\n" "ACCESS_TOKEN=\"${ACCESS_TOKEN}\"\nACCESS_TOKEN_EXPIRY=\"${ACCESS_TOKEN_EXPIRY}\"" >| "${TMPFILE}_ACCESS_TOKEN"
+        SERVICE_ACCOUNT="SA_$(_json_value private_key_id 1 1 < "${SERVICE_ACCOUNT_FILE}")_SA" ||
+            { "${QUIET:-_print_center}" 'normal' "Error: Invalid service account file." "=" 1>&2 && return 1; }
+
+        SA_ACCESS_TOKEN_NAME="${SERVICE_ACCOUNT}_ACCESS_TOKEN" \
+            SA_ACCESS_TOKEN_EXPIRY_NAME="${SA_ACCESS_TOKEN_NAME}_EXPIRY"
+
+        SERVICE_ACCOUNT_ACCESS_TOKEN="${!SA_ACCESS_TOKEN_NAME}"
+        SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY="${!SA_ACCESS_TOKEN_EXPIRY_NAME}"
+
+        [[ -z ${SERVICE_ACCOUNT_ACCESS_TOKEN} || ${SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY:-0} -lt "$(printf "%(%s)T\\n" "-1")" ]] || ! [[ ${SERVICE_ACCOUNT_ACCESS_TOKEN} =~ ${ACCESS_TOKEN_REGEX} ]] && {
+            ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || { printf "%s\n" "${ASSERTION_DATA}" 1>&2 && return 1; }
+            _get_access_token_and_update sa "${ASSERTION_DATA}" || return 1
+        }
+
+        printf "%s\n%s\n" "ACCESS_TOKEN=\"${!SA_ACCESS_TOKEN_NAME}\"" \
+            "ACCESS_TOKEN_EXPIRY=\"${!SA_ACCESS_TOKEN_EXPIRY_NAME}\"" >| "${TMPFILE}_ACCESS_TOKEN"
+    fi
 
     # launch a background service to check access token and update it
     # checks ACCESS_TOKEN_EXPIRY, try to update before 5 mins of expiry, a fresh token gets 60 mins
     # process will be killed when script exits or "${MAIN_PID}" is killed
     {
         until ! kill -0 "${MAIN_PID}" 2>| /dev/null 1>&2; do
+            unset ASSERTION_DATA MODE
             . "${TMPFILE}_ACCESS_TOKEN"
             CURRENT_TIME="$(printf "%(%s)T\\n" "-1")"
             REMAINING_TOKEN_TIME="$((ACCESS_TOKEN_EXPIRY - CURRENT_TIME))"
             if [[ ${REMAINING_TOKEN_TIME} -le 300 ]]; then
+                [[ -n ${SERVICE_ACCOUNT_FILE} ]] && {
+                    ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || :
+                    MODE="sa"
+                }
                 # timeout after 30 seconds, it shouldn't take too long anyway, and update tmp config
-                CONFIG="${TMPFILE}_ACCESS_TOKEN" _timeout 30 _get_access_token_and_update || :
+                SERVICE_ACCOUNT="" CONFIG="${TMPFILE}_ACCESS_TOKEN" _timeout 30 _get_access_token_and_update "${MODE:-normal}" "${ASSERTION_DATA:-}" || :
             else
                 TOKEN_PROCESS_TIME_TO_SLEEP="$(if [[ ${REMAINING_TOKEN_TIME} -le 301 ]]; then
                     printf "0\n"
@@ -1346,7 +1434,7 @@ _check_credentials() {
             fi
             sleep 1
         done
-    } &
+    } 2>| /dev/null 1>&2 &
     ACCESS_TOKEN_SERVICE_PID="${!}"
 
     return 0
@@ -1445,7 +1533,7 @@ _process_arguments() {
 
     export -f _bytes_to_human _dirname _json_value _url_encode _support_ansi_escapes _newline _print_center_quiet _print_center _clear_line \
         _api_request _get_access_token_and_update _check_existing_file _upload_file _upload_file_main _clone_file _collect_file_info _generate_upload_link _upload_file_from_uri _full_upload \
-        _normal_logging_upload _error_logging_upload _log_upload_session _remove_upload_session _upload_folder _share_id _get_rootdir_id
+        _normal_logging_upload _error_logging_upload _log_upload_session _remove_upload_session _upload_folder _share_id _get_rootdir_id _generate_jwt
 
     # on successful uploads
     _share_and_print_link() {
@@ -1619,8 +1707,8 @@ main() {
                 # update the config with latest ACCESS_TOKEN and ACCESS_TOKEN_EXPIRY only if changed
                 . "${TMPFILE}_ACCESS_TOKEN"
                 [[ ${INITIAL_ACCESS_TOKEN} = "${ACCESS_TOKEN}" ]] || {
-                    _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-                    _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                    _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
+                    _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
                 }
             } 1>| /dev/null
 

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -325,7 +325,7 @@ _update_config() {
     chmod u+w "${config_path}"
     printf "%s\n%s\n" "$(grep -v -e "^$" -e "^${value_name}=" "${config_path}" || :)" \
         "${value_name}=\"${value}\"" >| "${config_path}"
-    chmod u-w+r "${config_path}"
+    chmod a-w-r-x,u+r "${config_path}"
 }
 
 ###################################################
@@ -1019,9 +1019,9 @@ _cleanup_config() {
 
     done <<< "$(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)"
 
-    chmod +w "${config}" &&
+    chmod u+w "${config}" &&
         printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
-        chmod -w "${config}"
+        chmod "a-w-r-x,u+r" "${config}"
     return 0
 }
 

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -555,6 +555,8 @@ _get_access_token_and_update() {
         ACCESS_TOKEN_EXPIRY="$(($(printf "%(%s)T\\n" "-1") + $(_json_value expires_in 1 1 <<< "${RESPONSE}") - 1))"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+        _update_config "ACCESS_TOKEN" "${ACCESS_TOKEN}" "${TMPFILE}_ACCESS_TOKEN"
+        _update_config "ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${TMPFILE}_ACCESS_TOKEN"
     else
         "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
         printf "%s\n" "${RESPONSE}" 1>&2
@@ -1287,18 +1289,19 @@ _setup_arguments() {
 # Result: read description
 ###################################################
 _check_credentials() {
-    # Config file is created automatically after first run
-    [[ -r ${CONFIG} ]] && . "${CONFIG}"
-    "${UPDATE_DEFAULT_CONFIG:-:}" CONFIG "${CONFIG}" "${CONFIG_INFO}"
-
-    ! [[ -t 1 ]] && [[ -z ${CLIENT_ID:+${CLIENT_SECRET:+${REFRESH_TOKEN}}} ]] && {
-        printf "%s\n" "Error: Script is not running in a terminal, cannot ask for credentials."
-        printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
-    }
 
     ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+' # 2048 bytes
 
     if [[ -z ${SERVICE_ACCOUNT_FILE} ]]; then
+        # Config file is created automatically after first run
+        [[ -r ${CONFIG} ]] && . "${CONFIG}"
+        "${UPDATE_DEFAULT_CONFIG:-:}" CONFIG "${CONFIG}" "${CONFIG_INFO}"
+
+        ! [[ -t 1 ]] && [[ -z ${CLIENT_ID:+${CLIENT_SECRET:+${REFRESH_TOKEN}}} ]] && {
+            printf "%s\n" "Error: Script is not running in a terminal, cannot ask for credentials."
+            printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
+        }
+
         # Following https://developers.google.com/identity/protocols/oauth2#size
         CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
         CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
@@ -1403,9 +1406,6 @@ _check_credentials() {
             ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || { printf "%s\n" "${ASSERTION_DATA}" 1>&2 && return 1; }
             _get_access_token_and_update sa "${ASSERTION_DATA}" || return 1
         }
-
-        printf "%s\n%s\n" "ACCESS_TOKEN=\"${!SA_ACCESS_TOKEN_NAME}\"" \
-            "ACCESS_TOKEN_EXPIRY=\"${!SA_ACCESS_TOKEN_EXPIRY_NAME}\"" >| "${TMPFILE}_ACCESS_TOKEN"
     fi
 
     # launch a background service to check access token and update it
@@ -1709,6 +1709,8 @@ main() {
                 [[ ${INITIAL_ACCESS_TOKEN} = "${ACCESS_TOKEN}" ]] || {
                     _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
                     _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                    _update_config "ACCESS_TOKEN" "${ACCESS_TOKEN}" "${TMPFILE}_ACCESS_TOKEN"
+                    _update_config "ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${TMPFILE}_ACCESS_TOKEN"
                 }
             } 1>| /dev/null
 

--- a/bash/release/gupload
+++ b/bash/release/gupload
@@ -862,12 +862,14 @@ _upload_file_main() {
     retry="${RETRY:-0}" && unset RETURN_STATUS
     until [[ ${retry} -le 0 ]] && [[ -n ${RETURN_STATUS} ]]; do
         if [[ -n ${4} ]]; then
-            _upload_file "${UPLOAD_MODE:-create}" "${file}" "${dirid}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break
+            { _upload_file "${UPLOAD_MODE:-create}" "${file}" "${dirid}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break; } || RETURN_STATUS=2
         else
-            _upload_file "${UPLOAD_MODE:-create}" "${file}" "${dirid}" && RETURN_STATUS=1 && break
+            { _upload_file "${UPLOAD_MODE:-create}" "${file}" "${dirid}" && RETURN_STATUS=1 && break; } || RETURN_STATUS=2
         fi
-        sleep "$((_sleep += 1))" # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
-        RETURN_STATUS=2 retry="$((retry - 1))" && continue
+        # decrease retry using -=, skip sleep if all retries done
+        [[ $((retry -= 1)) -gt 1 ]] && sleep "$((_sleep += 1))"
+        # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
+        continue
     done
     { [[ ${RETURN_STATUS} = 1 ]] && printf "%b" "${4:+${RETURN_STATUS}\n}"; } || printf "%b" "${4:+${RETURN_STATUS}\n}" 1>&2
     return 0

--- a/bash/upload.bash
+++ b/bash/upload.bash
@@ -86,9 +86,9 @@ _cleanup_config() {
 
     done <<< "$(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)"
 
-    chmod +w "${config}" &&
+    chmod u+w "${config}" &&
         printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
-        chmod -w "${config}"
+        chmod "a-w-r-x,u+r" "${config}"
     return 0
 }
 

--- a/bash/upload.bash
+++ b/bash/upload.bash
@@ -298,18 +298,19 @@ _setup_arguments() {
 # Result: read description
 ###################################################
 _check_credentials() {
-    # Config file is created automatically after first run
-    [[ -r ${CONFIG} ]] && . "${CONFIG}"
-    "${UPDATE_DEFAULT_CONFIG:-:}" CONFIG "${CONFIG}" "${CONFIG_INFO}"
-
-    ! [[ -t 1 ]] && [[ -z ${CLIENT_ID:+${CLIENT_SECRET:+${REFRESH_TOKEN}}} ]] && {
-        printf "%s\n" "Error: Script is not running in a terminal, cannot ask for credentials."
-        printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
-    }
 
     ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+' # 2048 bytes
 
     if [[ -z ${SERVICE_ACCOUNT_FILE} ]]; then
+        # Config file is created automatically after first run
+        [[ -r ${CONFIG} ]] && . "${CONFIG}"
+        "${UPDATE_DEFAULT_CONFIG:-:}" CONFIG "${CONFIG}" "${CONFIG_INFO}"
+
+        ! [[ -t 1 ]] && [[ -z ${CLIENT_ID:+${CLIENT_SECRET:+${REFRESH_TOKEN}}} ]] && {
+            printf "%s\n" "Error: Script is not running in a terminal, cannot ask for credentials."
+            printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
+        }
+
         # Following https://developers.google.com/identity/protocols/oauth2#size
         CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
         CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
@@ -414,9 +415,6 @@ _check_credentials() {
             ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || { printf "%s\n" "${ASSERTION_DATA}" 1>&2 && return 1; }
             _get_access_token_and_update sa "${ASSERTION_DATA}" || return 1
         }
-
-        printf "%s\n%s\n" "ACCESS_TOKEN=\"${!SA_ACCESS_TOKEN_NAME}\"" \
-            "ACCESS_TOKEN_EXPIRY=\"${!SA_ACCESS_TOKEN_EXPIRY_NAME}\"" >| "${TMPFILE}_ACCESS_TOKEN"
     fi
 
     # launch a background service to check access token and update it
@@ -720,6 +718,8 @@ main() {
                 [[ ${INITIAL_ACCESS_TOKEN} = "${ACCESS_TOKEN}" ]] || {
                     _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
                     _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                    _update_config "ACCESS_TOKEN" "${ACCESS_TOKEN}" "${TMPFILE}_ACCESS_TOKEN"
+                    _update_config "ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${TMPFILE}_ACCESS_TOKEN"
                 }
             } 1>| /dev/null
 

--- a/install.sh
+++ b/install.sh
@@ -92,22 +92,28 @@ _check_dependencies() {
             command -v "${program}" 2>| /dev/null 1>&2 || error_list="${error_list}\n${program}"
         done
 
-    command -v tail 2>| /dev/null 1>&2 || warning_list="${warning_list}\ntail"
+    command -v tail 2>| /dev/null 1>&2 || sync_error="tail"
 
-    [ -n "${warning_list}" ] && {
-        [ -z "${UNINSTALL}" ] && {
+    command -v openssl 2>| /dev/null 1>&2 ||
+        openssl_error="openssl not installed. If not installed, service accounts ( '-sa | --service-account' flag ) will not work."
+
+    [ -z "${UNINSTALL}" ] && {
+
+        [ -n "${sync_error}" ] && {
             printf "Warning: "
-            printf "%b, " "${error_list}"
+            printf "%b, " "${sync_error}"
             printf "%b" "not found, sync script will be not installed/updated.\n"
+            SKIP_SYNC="true"
         }
-        SKIP_SYNC="true"
-    }
 
-    [ -n "${error_list}" ] && [ -z "${UNINSTALL}" ] && {
-        printf "Error: "
-        printf "%b, " "${error_list}"
-        printf "%b" "not found, install before proceeding.\n"
-        exit 1
+        [ -n "${openssl_error}" ] && printf "%s\n" "Warning: ${openssl_error}"
+
+        [ -n "${error_list}" ] && {
+            printf "Error: "
+            printf "%b, " "${error_list}"
+            printf "%b" "not found, install before proceeding.\n"
+            exit 1
+        }
     }
     return 0
 }

--- a/sh/common-utils.sh
+++ b/sh/common-utils.sh
@@ -310,7 +310,7 @@ _update_config() {
     chmod u+w "${config_path_update_config}"
     printf "%s\n%s\n" "$(grep -v -e "^$" -e "^${value_name_update_config}=" "${config_path_update_config}" || :)" \
         "${value_name_update_config}=\"${value_update_config}\"" >| "${config_path_update_config}"
-    chmod u-w+r "${config_path_update_config}"
+    chmod a-w-r-x,u+r "${config_path_update_config}"
 }
 
 ###################################################

--- a/sh/drive-utils.sh
+++ b/sh/drive-utils.sh
@@ -207,6 +207,8 @@ _get_access_token_and_update() {
         ACCESS_TOKEN_EXPIRY="$(($(date +"%s") + $(printf "%s\n" "${RESPONSE}" | _json_value expires_in 1 1) - 1))"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+        _update_config "ACCESS_TOKEN" "${ACCESS_TOKEN}" "${TMPFILE}_ACCESS_TOKEN"
+        _update_config "ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${TMPFILE}_ACCESS_TOKEN"
     else
         "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
         printf "%s\n" "${RESPONSE}" 1>&2

--- a/sh/google-oauth2.sh
+++ b/sh/google-oauth2.sh
@@ -113,7 +113,7 @@ if [ "${1}" = create ]; then
     _clear_line 1 1>&2
 
     REFRESH_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value refresh_token 1 1 || :)"
-    if _get_access_token_and_update "${RESPONSE}"; then
+    if _get_access_token_and_update normal "${RESPONSE}"; then
         _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"
         printf "Access Token: %s\n" "${ACCESS_TOKEN}"
         printf "Refresh Token: %s\n" "${REFRESH_TOKEN}"
@@ -123,7 +123,7 @@ if [ "${1}" = create ]; then
 elif [ "${1}" = refresh ]; then
     if [ -n "${REFRESH_TOKEN}" ]; then
         "${QUIET:-_print_center}" "justify" "Required credentials set." "="
-        { _get_access_token_and_update && _clear_line 1; } || return 1
+        { _get_access_token_and_update normal && _clear_line 1; } || return 1
         printf "Access Token: %s\n" "${ACCESS_TOKEN}"
     else
         "${QUIET:-_print_center}" "normal" "Refresh Token not set" ", use ${0##*/} create to generate one." "="

--- a/sh/release/gsync
+++ b/sh/release/gsync
@@ -311,7 +311,7 @@ _update_config() {
     chmod u+w "${config_path_update_config}"
     printf "%s\n%s\n" "$(grep -v -e "^$" -e "^${value_name_update_config}=" "${config_path_update_config}" || :)" \
         "${value_name_update_config}=\"${value_update_config}\"" >| "${config_path_update_config}"
-    chmod u-w+r "${config_path_update_config}"
+    chmod a-w-r-x,u+r "${config_path_update_config}"
 }
 
 ###################################################

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -538,6 +538,8 @@ _get_access_token_and_update() {
         ACCESS_TOKEN_EXPIRY="$(($(date +"%s") + $(printf "%s\n" "${RESPONSE}" | _json_value expires_in 1 1) - 1))"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
         _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+        _update_config "ACCESS_TOKEN" "${ACCESS_TOKEN}" "${TMPFILE}_ACCESS_TOKEN"
+        _update_config "ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${TMPFILE}_ACCESS_TOKEN"
     else
         "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
         printf "%s\n" "${RESPONSE}" 1>&2
@@ -1293,18 +1295,19 @@ _setup_arguments() {
 # Result: read description
 ###################################################
 _check_credentials() {
-    # Config file is created automatically after first run
-    [ -r "${CONFIG}" ] && . "${CONFIG}"
-    "${UPDATE_DEFAULT_CONFIG:-:}" CONFIG "${CONFIG}" "${CONFIG_INFO}"
-
-    ! [ -t 1 ] && [ -z "${CLIENT_ID:+${CLIENT_SECRET:+${REFRESH_TOKEN}}}" ] && {
-        printf "%s\n" "Error: Script is not running in a terminal, cannot ask for credentials."
-        printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
-    }
 
     ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+' # 2048 bytes
 
     if [ -z "${SERVICE_ACCOUNT_FILE}" ]; then
+        # Config file is created automatically after first run
+        [ -r "${CONFIG}" ] && . "${CONFIG}"
+        "${UPDATE_DEFAULT_CONFIG:-:}" CONFIG "${CONFIG}" "${CONFIG_INFO}"
+
+        ! [ -t 1 ] && [ -z "${CLIENT_ID:+${CLIENT_SECRET:+${REFRESH_TOKEN}}}" ] && {
+            printf "%s\n" "Error: Script is not running in a terminal, cannot ask for credentials."
+            printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
+        }
+
         # Following https://developers.google.com/identity/protocols/oauth2#size
         CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
         CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
@@ -1407,9 +1410,6 @@ _check_credentials() {
             ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || { printf "%s\n" "${ASSERTION_DATA}" 1>&2 && return 1; }
             _get_access_token_and_update sa "${ASSERTION_DATA}" || return 1
         }
-
-        printf "%s\n%s\n" "ACCESS_TOKEN=\"$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN"\")"\" \
-            "ACCESS_TOKEN_EXPIRY=\"$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN_EXPIRY"\")"\" >| "${TMPFILE}_ACCESS_TOKEN"
     fi
 
     # launch a background service to check access token and update it
@@ -1728,6 +1728,8 @@ main() {
                 [ "${INITIAL_ACCESS_TOKEN}" = "${ACCESS_TOKEN}" ] || {
                     _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
                     _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                    _update_config "ACCESS_TOKEN" "${ACCESS_TOKEN}" "${TMPFILE}_ACCESS_TOKEN"
+                    _update_config "ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${TMPFILE}_ACCESS_TOKEN"
                 }
             } 1>| /dev/null
 

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -311,7 +311,7 @@ _update_config() {
     chmod u+w "${config_path_update_config}"
     printf "%s\n%s\n" "$(grep -v -e "^$" -e "^${value_name_update_config}=" "${config_path_update_config}" || :)" \
         "${value_name_update_config}=\"${value_update_config}\"" >| "${config_path_update_config}"
-    chmod u-w+r "${config_path_update_config}"
+    chmod a-w-r-x,u+r "${config_path_update_config}"
 }
 
 ###################################################
@@ -1006,9 +1006,9 @@ _cleanup_config() {
 $(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)
 EOF
 
-    chmod +w "${config}" &&
+    chmod u+w "${config}" &&
         printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
-        chmod -w "${config}"
+        chmod "a-w-r-x,u+r" "${config}"
     return 0
 }
 

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -520,11 +520,24 @@ _extract_id() {
 # Result: Update access_token and expiry else print error
 ###################################################
 _get_access_token_and_update() {
-    RESPONSE="${1:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+    case "${1:?Error: sa or normal}" in
+        normal)
+            RESPONSE="${2:-$(curl --compressed -s -X POST --data "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" "${TOKEN_URL}")}" || :
+            ;;
+        sa)
+            assertion_data="${2:?Error: Missing assertion data.}"
+            RESPONSE="$(curl --compressed -s --data "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${assertion_data}" "${TOKEN_URL}")" || :
+            # sa token jsons are not pretty printed
+            # shellcheck disable=SC1004
+            RESPONSE="$(printf "%s\n" "${RESPONSE}" | sed -e 's/,"/\
+"/g')"
+            ;;
+    esac
+
     if ACCESS_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value access_token 1 1)"; then
         ACCESS_TOKEN_EXPIRY="$(($(date +"%s") + $(printf "%s\n" "${RESPONSE}" | _json_value expires_in 1 1) - 1))"
-        _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-        _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+        _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
+        _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
     else
         "${QUIET:-_print_center}" "justify" "Error: Something went wrong" ", printing error." "=" 1>&2
         printf "%s\n" "${RESPONSE}" 1>&2
@@ -808,6 +821,57 @@ _error_logging_upload() {
 }
 
 ###################################################
+# Generate rs256 jwt just with cli commands and shell
+# Specifically for gdrive service accounts usage
+# Globals: 1
+#  SCOPE ( optional )
+# Arguments: 2
+#   ${1} = service account json file
+#   ${2} = SCOPE for gdrive
+# Result: print jwt
+# Refrences:
+#   https://stackoverflow.com/questions/46657001/how-do-you-create-an-rs256-jwt-assertion-with-bash-shell-scripting
+#   Inspired by implementation by Will Haley at:
+#     http://willhaley.com/blog/generate-jwt-with-bash/
+###################################################
+_generate_jwt() {
+    json_file_generate_jwt="${1:?Error: Give service json file name}"
+    scope_generate_jwt="${2:-${SCOPE:?Error: Missing scope}}"
+    aud_generate_jwt="https://oauth2.googleapis.com/token"
+    header_generate_jwt='{"alg":"RS256","typ":"JWT"}'
+    algo_generate_jwt="256"
+    unset payload_data_generate_jwt iss_generate_jwt exp_generate_jwt iat_generate_jwt rsa_secret_generate_jwt \
+        signed_content_generate_jwt sign_generate_jwt
+
+    if iss_generate_jwt="$(_json_value client_email 1 1 < "${json_file_generate_jwt}")" &&
+        rsa_secret_generate_jwt="$(_json_value private_key 1 1 < "${json_file_generate_jwt}")"; then
+        rsa_secret_generate_jwt="$(printf "%b\n" "${rsa_secret_generate_jwt}")"
+    else
+        "${QUIET:-_print_center}" 'normal' "Error: Invalid service account file." "=" && return 1
+    fi
+
+    iat_generate_jwt="$(date +"%s")" exp_generate_jwt="$((iat_generate_jwt + 3400))"
+
+    b64enc() { openssl enc -base64 -A | sed -e "s|+|-|g" -e "s|/|_|g" -e "s|=||g"; }
+
+    payload_data_generate_jwt='{"iss":"'${iss_generate_jwt}'","scope":"'${scope_generate_jwt}'","aud":"'${aud_generate_jwt}'","exp":'${exp_generate_jwt}',"iat":'${iat_generate_jwt}'}'
+
+    {
+        signed_content_generate_jwt="$(printf "%s\n" "${header_generate_jwt}" | b64enc).$(printf "%s\n" "${payload_data_generate_jwt}" | b64enc)"
+        # Open file discriptor for rsa_secret
+        exec 5<< EOF
+$(printf "%s\n" "${rsa_secret_generate_jwt}")
+EOF
+        sign_generate_jwt="$(printf %s "${signed_content_generate_jwt}" | openssl dgst -binary -sha"${algo_generate_jwt}" -sign /dev/fd/5 | b64enc)"
+        # close file discriptor
+        exec 5<&-
+    } || return 1
+
+    printf '%s.%s\n' "${signed_content_generate_jwt}" "${sign_generate_jwt}"
+    return 0
+}
+
+###################################################
 # A small function to get rootdir id for files in sub folder uploads
 # Globals: 1 variable, 1 function
 #   Variables - DIRIDS
@@ -929,6 +993,7 @@ Usage:\n ${0##*/} [options.. ] <filename> <foldername>\n
 Foldername argument is optional. If not provided, the file will be uploaded to preconfigured google drive.\n
 File name argument is optional if create directory option is used.\n
 Options:\n
+  -sa | --service-accounts 'service account json file path' - Use a bot service account. Should be in proper json format.\n
   -c | -C | --create-dir <foldername> - option to create directory. Will provide folder id. Can be used to provide input folder, see README.\n
   -r | --root-dir <google_folderid> or <google_folder_url> - google folder ID/URL to which the file/directory is going to upload.
       If you want to change the default value, then use this format, -r/--root-dir default=root_folder_id/root_folder_url\n
@@ -1033,14 +1098,15 @@ _setup_arguments() {
     # De-initialize if any variables set already.
     unset FIRST_INPUT FOLDER_INPUT FOLDERNAME FINAL_LOCAL_INPUT_ARRAY FINAL_ID_INPUT_ARRAY
     unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_EMAIL OVERWRITE SKIP_DUPLICATES SKIP_SUBDIRS ROOTDIR QUIET
-    unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY
+    unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY OPENSSL_ERROR
     CURL_PROGRESS="-s" EXTRA_LOG=":" CURL_PROGRESS_EXTRA="-s"
     INFO_PATH="${HOME}/.google-drive-upload" CONFIG_INFO="${INFO_PATH}/google-drive-upload.configpath"
     [ -f "${CONFIG_INFO}" ] && . "${CONFIG_INFO}"
     CONFIG="${CONFIG:-${HOME}/.googledrive.conf}"
 
     # Configuration variables # Remote gDrive variables
-    unset ROOT_FOLDER CLIENT_ID CLIENT_SECRET REFRESH_TOKEN ACCESS_TOKEN
+    unset ROOT_FOLDER CLIENT_ID CLIENT_SECRET REFRESH_TOKEN ACCESS_TOKEN \
+        SERVICE_ACCOUNT SERVICE_ACCOUNT_ACCESS_TOKEN SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY
     API_URL="https://www.googleapis.com"
     API_VERSION="v3"
     SCOPE="${API_URL}/auth/drive"
@@ -1067,6 +1133,11 @@ _setup_arguments() {
             -h | --help) _usage ;;
             -D | --debug) DEBUG="true" && export DEBUG ;;
             --info) _version_info ;;
+            -sa | --service-account)
+                _check_longoptions "${1}" "${2}"
+                SERVICE_ACCOUNT_FILE="${2}"
+                ! [ -f "${SERVICE_ACCOUNT_FILE}" ] && printf "%s\n" "Error: Service account json file exist ( ${SERVICE_ACCOUNT_FILE} )." 1>&2 && exit 1
+                ;;
             -c | -C | --create-dir)
                 _check_longoptions "${1}" "${2}"
                 FOLDERNAME="${2}" && shift
@@ -1231,107 +1302,132 @@ _check_credentials() {
         printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
     }
 
-    # Following https://developers.google.com/identity/protocols/oauth2#size
-    CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
-    CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
-    REFRESH_TOKEN_REGEX='[0-9]//[0-9A-Za-z_-]+'     # 512 bytes
-    ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+'       # 2048 bytes
-    AUTHORIZATION_CODE_REGEX='[0-9]/[0-9A-Za-z_-]+' # 256 bytes
+    ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+' # 2048 bytes
 
-    until [ -n "${CLIENT_ID}" ] && [ -n "${CLIENT_ID_VALID}" ]; do
-        [ -n "${CLIENT_ID}" ] && {
-            if printf "%s\n" "${CLIENT_ID}" | grep -qE "${CLIENT_ID_REGEX}"; then
-                [ -n "${client_id}" ] && _update_config CLIENT_ID "${CLIENT_ID}" "${CONFIG}"
-                CLIENT_ID_VALID="true" && continue
-            else
-                { [ -n "${client_id}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
-                "${QUIET:-_print_center}" "normal" " Invalid Client ID ${message} " "-" && unset CLIENT_ID client_id
-            fi
+    if [ -z "${SERVICE_ACCOUNT_FILE}" ]; then
+        # Following https://developers.google.com/identity/protocols/oauth2#size
+        CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
+        CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
+        REFRESH_TOKEN_REGEX='[0-9]//[0-9A-Za-z_-]+'     # 512 bytes
+        AUTHORIZATION_CODE_REGEX='[0-9]/[0-9A-Za-z_-]+' # 256 bytes
+
+        until [ -n "${CLIENT_ID}" ] && [ -n "${CLIENT_ID_VALID}" ]; do
+            [ -n "${CLIENT_ID}" ] && {
+                if printf "%s\n" "${CLIENT_ID}" | grep -qE "${CLIENT_ID_REGEX}"; then
+                    [ -n "${client_id}" ] && _update_config CLIENT_ID "${CLIENT_ID}" "${CONFIG}"
+                    CLIENT_ID_VALID="true" && continue
+                else
+                    { [ -n "${client_id}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
+                    "${QUIET:-_print_center}" "normal" " Invalid Client ID ${message} " "-" && unset CLIENT_ID client_id
+                fi
+            }
+            [ -z "${client_id}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client ID " "-"
+            [ -n "${client_id}" ] && _clear_line 1
+            printf -- "-> "
+            read -r CLIENT_ID && client_id=1
+        done
+
+        until [ -n "${CLIENT_SECRET}" ] && [ -n "${CLIENT_SECRET_VALID}" ]; do
+            [ -n "${CLIENT_SECRET}" ] && {
+                if printf "%s\n" "${CLIENT_SECRET}" | grep -qE "${CLIENT_SECRET_REGEX}"; then
+                    [ -n "${client_secret}" ] && _update_config CLIENT_SECRET "${CLIENT_SECRET}" "${CONFIG}"
+                    CLIENT_SECRET_VALID="true" && continue
+                else
+                    { [ -n "${client_secret}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
+                    "${QUIET:-_print_center}" "normal" " Invalid Client Secret ${message} " "-" && unset CLIENT_SECRET client_secret
+                fi
+            }
+            [ -z "${client_secret}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client Secret " "-"
+            [ -n "${client_secret}" ] && _clear_line 1
+            printf -- "-> "
+            read -r CLIENT_SECRET && client_secret=1
+        done
+
+        [ -n "${REFRESH_TOKEN}" ] && {
+            ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}" &&
+                "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token in config file, follow below steps.. " "-" && unset REFRESH_TOKEN
         }
-        [ -z "${client_id}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client ID " "-"
-        [ -n "${client_id}" ] && _clear_line 1
-        printf -- "-> "
-        read -r CLIENT_ID && client_id=1
-    done
-
-    until [ -n "${CLIENT_SECRET}" ] && [ -n "${CLIENT_SECRET_VALID}" ]; do
-        [ -n "${CLIENT_SECRET}" ] && {
-            if printf "%s\n" "${CLIENT_SECRET}" | grep -qE "${CLIENT_SECRET_REGEX}"; then
-                [ -n "${client_secret}" ] && _update_config CLIENT_SECRET "${CLIENT_SECRET}" "${CONFIG}"
-                CLIENT_SECRET_VALID="true" && continue
-            else
-                { [ -n "${client_secret}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
-                "${QUIET:-_print_center}" "normal" " Invalid Client Secret ${message} " "-" && unset CLIENT_SECRET client_secret
-            fi
-        }
-        [ -z "${client_secret}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client Secret " "-"
-        [ -n "${client_secret}" ] && _clear_line 1
-        printf -- "-> "
-        read -r CLIENT_SECRET && client_secret=1
-    done
-
-    [ -n "${REFRESH_TOKEN}" ] && {
-        ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}" &&
-            "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token in config file, follow below steps.. " "-" && unset REFRESH_TOKEN
-    }
-
-    [ -z "${REFRESH_TOKEN}" ] && {
-        printf "\n" && "${QUIET:-_print_center}" "normal" "If you have a refresh token generated, then type the token, else leave blank and press return key.." " "
-        printf "\n" && "${QUIET:-_print_center}" "normal" " Refresh Token " "-" && printf -- "-> "
-        read -r REFRESH_TOKEN
-        if [ -n "${REFRESH_TOKEN}" ]; then
-            "${QUIET:-_print_center}" "normal" " Checking refresh token.. " "-"
-            if ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}"; then
-                { _get_access_token_and_update && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || check_error=1
-            else
-                check_error=true
-            fi
-            [ -n "${check_error}" ] && "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token given, follow below steps to generate.. " "-" && unset REFRESH_TOKEN
-        else
-            "${QUIET:-_print_center}" "normal" " No Refresh token given, follow below steps to generate.. " "-"
-        fi
 
         [ -z "${REFRESH_TOKEN}" ] && {
-            printf "\n" && "${QUIET:-_print_center}" "normal" "Visit the below URL, tap on allow and then enter the code obtained" " "
-            URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code&prompt=consent"
-            printf "\n%s\n" "${URL}"
-            until [ -n "${AUTHORIZATION_CODE}" ] && [ -n "${AUTHORIZATION_CODE_VALID}" ]; do
-                [ -n "${AUTHORIZATION_CODE}" ] && {
-                    if printf "%s\n" "${AUTHORIZATION_CODE}" | grep -qE "${AUTHORIZATION_CODE_REGEX}"; then
-                        AUTHORIZATION_CODE_VALID="true" && continue
-                    else
-                        "${QUIET:-_print_center}" "normal" " Invalid CODE given, try again.. " "-" && unset AUTHORIZATION_CODE authorization_code
-                    fi
-                }
-                { [ -z "${authorization_code}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter the authorization code " "-"; } || _clear_line 1
-                printf -- "-> "
-                read -r AUTHORIZATION_CODE && authorization_code=1
-            done
-            RESPONSE="$(curl --compressed "${CURL_PROGRESS}" -X POST \
-                --data "code=${AUTHORIZATION_CODE}&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&redirect_uri=${REDIRECT_URI}&grant_type=authorization_code" "${TOKEN_URL}")" || :
-            _clear_line 1 1>&2
+            printf "\n" && "${QUIET:-_print_center}" "normal" "If you have a refresh token generated, then type the token, else leave blank and press return key.." " "
+            printf "\n" && "${QUIET:-_print_center}" "normal" " Refresh Token " "-" && printf -- "-> "
+            read -r REFRESH_TOKEN
+            if [ -n "${REFRESH_TOKEN}" ]; then
+                "${QUIET:-_print_center}" "normal" " Checking refresh token.. " "-"
+                if ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}"; then
+                    { _get_access_token_and_update normal && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || check_error=1
+                else
+                    check_error=true
+                fi
+                [ -n "${check_error}" ] && "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token given, follow below steps to generate.. " "-" && unset REFRESH_TOKEN
+            else
+                "${QUIET:-_print_center}" "normal" " No Refresh token given, follow below steps to generate.. " "-"
+            fi
 
-            REFRESH_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value refresh_token 1 1 || :)"
-            { _get_access_token_and_update "${RESPONSE}" && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || return 1
+            [ -z "${REFRESH_TOKEN}" ] && {
+                printf "\n" && "${QUIET:-_print_center}" "normal" "Visit the below URL, tap on allow and then enter the code obtained" " "
+                URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code&prompt=consent"
+                printf "\n%s\n" "${URL}"
+                until [ -n "${AUTHORIZATION_CODE}" ] && [ -n "${AUTHORIZATION_CODE_VALID}" ]; do
+                    [ -n "${AUTHORIZATION_CODE}" ] && {
+                        if printf "%s\n" "${AUTHORIZATION_CODE}" | grep -qE "${AUTHORIZATION_CODE_REGEX}"; then
+                            AUTHORIZATION_CODE_VALID="true" && continue
+                        else
+                            "${QUIET:-_print_center}" "normal" " Invalid CODE given, try again.. " "-" && unset AUTHORIZATION_CODE authorization_code
+                        fi
+                    }
+                    { [ -z "${authorization_code}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter the authorization code " "-"; } || _clear_line 1
+                    printf -- "-> "
+                    read -r AUTHORIZATION_CODE && authorization_code=1
+                done
+                RESPONSE="$(curl --compressed "${CURL_PROGRESS}" -X POST \
+                    --data "code=${AUTHORIZATION_CODE}&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&redirect_uri=${REDIRECT_URI}&grant_type=authorization_code" "${TOKEN_URL}")" || :
+                _clear_line 1 1>&2
+
+                REFRESH_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value refresh_token 1 1 || :)"
+                { _get_access_token_and_update normal "${RESPONSE}" && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || return 1
+            }
+            printf "\n"
         }
-        printf "\n"
-    }
 
-    { [ -z "${ACCESS_TOKEN}" ] || ! printf "%s\n" "${ACCESS_TOKEN}" | grep -qE "${ACCESS_TOKEN_REGEX}" || [ "${ACCESS_TOKEN_EXPIRY:-0}" -lt "$(date +'%s')" ]; } &&
-        { _get_access_token_and_update || return 1; }
-    printf "%b\n" "ACCESS_TOKEN=\"${ACCESS_TOKEN}\"\nACCESS_TOKEN_EXPIRY=\"${ACCESS_TOKEN_EXPIRY}\"" >| "${TMPFILE}_ACCESS_TOKEN"
+        { [ -z "${ACCESS_TOKEN}" ] || ! printf "%s\n" "${ACCESS_TOKEN}" | grep -qE "${ACCESS_TOKEN_REGEX}" || [ "${ACCESS_TOKEN_EXPIRY:-0}" -lt "$(date +'%s')" ]; } &&
+            { _get_access_token_and_update normal || return 1; }
+        printf "%b\n" "ACCESS_TOKEN=\"${ACCESS_TOKEN}\"\nACCESS_TOKEN_EXPIRY=\"${ACCESS_TOKEN_EXPIRY}\"" >| "${TMPFILE}_ACCESS_TOKEN"
+    else
+        command -v openssl 2>| /dev/null 1>&2 ||
+            { "${QUIET:-_print_center}" 'normal' "Error: openssl not installed, install openssl to use '-sa | --service-account' flag." "=" 1>&2 && return 1; }
+
+        SERVICE_ACCOUNT="SA_$(_json_value private_key_id 1 1 < "${SERVICE_ACCOUNT_FILE}")_SA" ||
+            { "${QUIET:-_print_center}" 'normal' "Error: Invalid service account file." "=" 1>&2 && return 1; }
+
+        SERVICE_ACCOUNT_ACCESS_TOKEN="$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN"\")"
+        SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY="$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN_EXPIRY"\")"
+
+        { [ -z "${SERVICE_ACCOUNT_ACCESS_TOKEN}" ] || ! printf "%s\n" "${SERVICE_ACCOUNT_ACCESS_TOKEN}" | grep -qE "${ACCESS_TOKEN_REGEX}" || [ "${SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY:-0}" -lt "$(date +'%s')" ]; } && {
+            ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || { printf "%s\n" "${ASSERTION_DATA}" 1>&2 && return 1; }
+            _get_access_token_and_update sa "${ASSERTION_DATA}" || return 1
+        }
+
+        printf "%s\n%s\n" "ACCESS_TOKEN=\"$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN"\")"\" \
+            "ACCESS_TOKEN_EXPIRY=\"$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN_EXPIRY"\")"\" >| "${TMPFILE}_ACCESS_TOKEN"
+    fi
 
     # launch a background service to check access token and update it
     # checks ACCESS_TOKEN_EXPIRY, try to update before 5 mins of expiry, a fresh token gets 60 mins
     # process will be killed when script exits or "${MAIN_PID}" is killed
     {
         until ! kill -0 "${MAIN_PID}" 2>| /dev/null 1>&2; do
+            unset ASSERTION_DATA MODE
             . "${TMPFILE}_ACCESS_TOKEN"
             CURRENT_TIME="$(date +'%s')"
             REMAINING_TOKEN_TIME="$((CURRENT_TIME - ACCESS_TOKEN_EXPIRY))"
             if [ "${REMAINING_TOKEN_TIME}" -le 300 ]; then
+                [ -n "${SERVICE_ACCOUNT_FILE}" ] && {
+                    ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || :
+                    MODE="sa"
+                }
                 # timeout after 30 seconds, it shouldn't take too long anyway, and update tmp config
-                CONFIG="${TMPFILE}_ACCESS_TOKEN" _timeout 30 _get_access_token_and_update || :
+                SERVICE_ACCOUNT="" CONFIG="${TMPFILE}_ACCESS_TOKEN" _timeout 30 _get_access_token_and_update "${MODE:-normal}" "${ASSERTION_DATA:-}" || :
             else
                 TOKEN_PROCESS_TIME_TO_SLEEP="$(if [ "${REMAINING_TOKEN_TIME}" -le 301 ]; then
                     printf "0\n"
@@ -1342,7 +1438,7 @@ _check_credentials() {
             fi
             sleep 1
         done
-    } &
+    } 2>| /dev/null 1>&2 &
     ACCESS_TOKEN_SERVICE_PID="${!}"
 
     return 0
@@ -1630,8 +1726,8 @@ main() {
             [ -f "${TMPFILE}_ACCESS_TOKEN" ] && {
                 . "${TMPFILE}_ACCESS_TOKEN"
                 [ "${INITIAL_ACCESS_TOKEN}" = "${ACCESS_TOKEN}" ] || {
-                    _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-                    _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                    _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
+                    _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
                 }
             } 1>| /dev/null
 

--- a/sh/release/gupload
+++ b/sh/release/gupload
@@ -844,14 +844,16 @@ _upload_file_main() {
     retry_upload_file_main="${RETRY:-0}" && unset RETURN_STATUS
     until [ "${retry_upload_file_main}" -le 0 ] && [ -n "${RETURN_STATUS}" ]; do
         if [ -n "${4}" ]; then
-            _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break
+            { _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break; } || RETURN_STATUS=2
         else
-            _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" && RETURN_STATUS=1 && break
+            { _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" && RETURN_STATUS=1 && break; } || RETURN_STATUS=2
         fi
-        sleep "$((sleep_upload_file_main += 1))" # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
-        RETURN_STATUS=2 retry_upload_file_main="$((retry_upload_file_main - 1))" && continue
+        # decrease retry using -=, skip sleep if all retries done
+        [ "$((retry_upload_file_main -= 1))" -gt 1 ] && sleep "$((sleep_upload_file_main += 1))"
+        # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
+        continue
     done
-    printf "%b" "${4:+${RETURN_STATUS}\n}" 1>&"${RETURN_STATUS}"
+    { [ "${RETURN_STATUS}" = 1 ] && printf "%b" "${4:+${RETURN_STATUS}\n}"; } || printf "%b" "${4:+${RETURN_STATUS}\n}" 1>&2
     return 0
 }
 

--- a/sh/upload-utils.sh
+++ b/sh/upload-utils.sh
@@ -91,14 +91,16 @@ _upload_file_main() {
     retry_upload_file_main="${RETRY:-0}" && unset RETURN_STATUS
     until [ "${retry_upload_file_main}" -le 0 ] && [ -n "${RETURN_STATUS}" ]; do
         if [ -n "${4}" ]; then
-            _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break
+            { _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" 2>| /dev/null 1>&2 && RETURN_STATUS=1 && break; } || RETURN_STATUS=2
         else
-            _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" && RETURN_STATUS=1 && break
+            { _upload_file "${UPLOAD_MODE:-create}" "${file_upload_file_main}" "${dirid_upload_file_main}" && RETURN_STATUS=1 && break; } || RETURN_STATUS=2
         fi
-        sleep "$((sleep_upload_file_main += 1))" # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
-        RETURN_STATUS=2 retry_upload_file_main="$((retry_upload_file_main - 1))" && continue
+        # decrease retry using -=, skip sleep if all retries done
+        [ "$((retry_upload_file_main -= 1))" -gt 1 ] && sleep "$((sleep_upload_file_main += 1))"
+        # on every retry, sleep the times of retry it is, e.g for 1st, sleep 1, for 2nd, sleep 2
+        continue
     done
-    printf "%b" "${4:+${RETURN_STATUS}\n}" 1>&"${RETURN_STATUS}"
+    { [ "${RETURN_STATUS}" = 1 ] && printf "%b" "${4:+${RETURN_STATUS}\n}"; } || printf "%b" "${4:+${RETURN_STATUS}\n}" 1>&2
     return 0
 }
 

--- a/sh/upload.sh
+++ b/sh/upload.sh
@@ -9,6 +9,7 @@ Usage:\n ${0##*/} [options.. ] <filename> <foldername>\n
 Foldername argument is optional. If not provided, the file will be uploaded to preconfigured google drive.\n
 File name argument is optional if create directory option is used.\n
 Options:\n
+  -sa | --service-accounts 'service account json file path' - Use a bot service account. Should be in proper json format.\n
   -c | -C | --create-dir <foldername> - option to create directory. Will provide folder id. Can be used to provide input folder, see README.\n
   -r | --root-dir <google_folderid> or <google_folder_url> - google folder ID/URL to which the file/directory is going to upload.
       If you want to change the default value, then use this format, -r/--root-dir default=root_folder_id/root_folder_url\n
@@ -113,14 +114,15 @@ _setup_arguments() {
     # De-initialize if any variables set already.
     unset FIRST_INPUT FOLDER_INPUT FOLDERNAME FINAL_LOCAL_INPUT_ARRAY FINAL_ID_INPUT_ARRAY
     unset PARALLEL NO_OF_PARALLEL_JOBS SHARE SHARE_EMAIL OVERWRITE SKIP_DUPLICATES SKIP_SUBDIRS ROOTDIR QUIET
-    unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY
+    unset VERBOSE VERBOSE_PROGRESS DEBUG LOG_FILE_ID CURL_SPEED RETRY OPENSSL_ERROR
     CURL_PROGRESS="-s" EXTRA_LOG=":" CURL_PROGRESS_EXTRA="-s"
     INFO_PATH="${HOME}/.google-drive-upload" CONFIG_INFO="${INFO_PATH}/google-drive-upload.configpath"
     [ -f "${CONFIG_INFO}" ] && . "${CONFIG_INFO}"
     CONFIG="${CONFIG:-${HOME}/.googledrive.conf}"
 
     # Configuration variables # Remote gDrive variables
-    unset ROOT_FOLDER CLIENT_ID CLIENT_SECRET REFRESH_TOKEN ACCESS_TOKEN
+    unset ROOT_FOLDER CLIENT_ID CLIENT_SECRET REFRESH_TOKEN ACCESS_TOKEN \
+        SERVICE_ACCOUNT SERVICE_ACCOUNT_ACCESS_TOKEN SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY
     API_URL="https://www.googleapis.com"
     API_VERSION="v3"
     SCOPE="${API_URL}/auth/drive"
@@ -147,6 +149,11 @@ _setup_arguments() {
             -h | --help) _usage ;;
             -D | --debug) DEBUG="true" && export DEBUG ;;
             --info) _version_info ;;
+            -sa | --service-account)
+                _check_longoptions "${1}" "${2}"
+                SERVICE_ACCOUNT_FILE="${2}"
+                ! [ -f "${SERVICE_ACCOUNT_FILE}" ] && printf "%s\n" "Error: Service account json file exist ( ${SERVICE_ACCOUNT_FILE} )." 1>&2 && exit 1
+                ;;
             -c | -C | --create-dir)
                 _check_longoptions "${1}" "${2}"
                 FOLDERNAME="${2}" && shift
@@ -311,107 +318,132 @@ _check_credentials() {
         printf "%s\n" "Add in config manually if terminal is not accessible. CLIENT_ID, CLIENT_SECRET and REFRESH_TOKEN is required." && return 1
     }
 
-    # Following https://developers.google.com/identity/protocols/oauth2#size
-    CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
-    CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
-    REFRESH_TOKEN_REGEX='[0-9]//[0-9A-Za-z_-]+'     # 512 bytes
-    ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+'       # 2048 bytes
-    AUTHORIZATION_CODE_REGEX='[0-9]/[0-9A-Za-z_-]+' # 256 bytes
+    ACCESS_TOKEN_REGEX='ya29\.[0-9A-Za-z_-]+' # 2048 bytes
 
-    until [ -n "${CLIENT_ID}" ] && [ -n "${CLIENT_ID_VALID}" ]; do
-        [ -n "${CLIENT_ID}" ] && {
-            if printf "%s\n" "${CLIENT_ID}" | grep -qE "${CLIENT_ID_REGEX}"; then
-                [ -n "${client_id}" ] && _update_config CLIENT_ID "${CLIENT_ID}" "${CONFIG}"
-                CLIENT_ID_VALID="true" && continue
-            else
-                { [ -n "${client_id}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
-                "${QUIET:-_print_center}" "normal" " Invalid Client ID ${message} " "-" && unset CLIENT_ID client_id
-            fi
+    if [ -z "${SERVICE_ACCOUNT_FILE}" ]; then
+        # Following https://developers.google.com/identity/protocols/oauth2#size
+        CLIENT_ID_REGEX='[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
+        CLIENT_SECRET_REGEX='[0-9A-Za-z_-]+'
+        REFRESH_TOKEN_REGEX='[0-9]//[0-9A-Za-z_-]+'     # 512 bytes
+        AUTHORIZATION_CODE_REGEX='[0-9]/[0-9A-Za-z_-]+' # 256 bytes
+
+        until [ -n "${CLIENT_ID}" ] && [ -n "${CLIENT_ID_VALID}" ]; do
+            [ -n "${CLIENT_ID}" ] && {
+                if printf "%s\n" "${CLIENT_ID}" | grep -qE "${CLIENT_ID_REGEX}"; then
+                    [ -n "${client_id}" ] && _update_config CLIENT_ID "${CLIENT_ID}" "${CONFIG}"
+                    CLIENT_ID_VALID="true" && continue
+                else
+                    { [ -n "${client_id}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
+                    "${QUIET:-_print_center}" "normal" " Invalid Client ID ${message} " "-" && unset CLIENT_ID client_id
+                fi
+            }
+            [ -z "${client_id}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client ID " "-"
+            [ -n "${client_id}" ] && _clear_line 1
+            printf -- "-> "
+            read -r CLIENT_ID && client_id=1
+        done
+
+        until [ -n "${CLIENT_SECRET}" ] && [ -n "${CLIENT_SECRET_VALID}" ]; do
+            [ -n "${CLIENT_SECRET}" ] && {
+                if printf "%s\n" "${CLIENT_SECRET}" | grep -qE "${CLIENT_SECRET_REGEX}"; then
+                    [ -n "${client_secret}" ] && _update_config CLIENT_SECRET "${CLIENT_SECRET}" "${CONFIG}"
+                    CLIENT_SECRET_VALID="true" && continue
+                else
+                    { [ -n "${client_secret}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
+                    "${QUIET:-_print_center}" "normal" " Invalid Client Secret ${message} " "-" && unset CLIENT_SECRET client_secret
+                fi
+            }
+            [ -z "${client_secret}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client Secret " "-"
+            [ -n "${client_secret}" ] && _clear_line 1
+            printf -- "-> "
+            read -r CLIENT_SECRET && client_secret=1
+        done
+
+        [ -n "${REFRESH_TOKEN}" ] && {
+            ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}" &&
+                "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token in config file, follow below steps.. " "-" && unset REFRESH_TOKEN
         }
-        [ -z "${client_id}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client ID " "-"
-        [ -n "${client_id}" ] && _clear_line 1
-        printf -- "-> "
-        read -r CLIENT_ID && client_id=1
-    done
-
-    until [ -n "${CLIENT_SECRET}" ] && [ -n "${CLIENT_SECRET_VALID}" ]; do
-        [ -n "${CLIENT_SECRET}" ] && {
-            if printf "%s\n" "${CLIENT_SECRET}" | grep -qE "${CLIENT_SECRET_REGEX}"; then
-                [ -n "${client_secret}" ] && _update_config CLIENT_SECRET "${CLIENT_SECRET}" "${CONFIG}"
-                CLIENT_SECRET_VALID="true" && continue
-            else
-                { [ -n "${client_secret}" ] && message="- Try again"; } || message="in config ( ${CONFIG} )"
-                "${QUIET:-_print_center}" "normal" " Invalid Client Secret ${message} " "-" && unset CLIENT_SECRET client_secret
-            fi
-        }
-        [ -z "${client_secret}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter Client Secret " "-"
-        [ -n "${client_secret}" ] && _clear_line 1
-        printf -- "-> "
-        read -r CLIENT_SECRET && client_secret=1
-    done
-
-    [ -n "${REFRESH_TOKEN}" ] && {
-        ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}" &&
-            "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token in config file, follow below steps.. " "-" && unset REFRESH_TOKEN
-    }
-
-    [ -z "${REFRESH_TOKEN}" ] && {
-        printf "\n" && "${QUIET:-_print_center}" "normal" "If you have a refresh token generated, then type the token, else leave blank and press return key.." " "
-        printf "\n" && "${QUIET:-_print_center}" "normal" " Refresh Token " "-" && printf -- "-> "
-        read -r REFRESH_TOKEN
-        if [ -n "${REFRESH_TOKEN}" ]; then
-            "${QUIET:-_print_center}" "normal" " Checking refresh token.. " "-"
-            if ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}"; then
-                { _get_access_token_and_update && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || check_error=1
-            else
-                check_error=true
-            fi
-            [ -n "${check_error}" ] && "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token given, follow below steps to generate.. " "-" && unset REFRESH_TOKEN
-        else
-            "${QUIET:-_print_center}" "normal" " No Refresh token given, follow below steps to generate.. " "-"
-        fi
 
         [ -z "${REFRESH_TOKEN}" ] && {
-            printf "\n" && "${QUIET:-_print_center}" "normal" "Visit the below URL, tap on allow and then enter the code obtained" " "
-            URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code&prompt=consent"
-            printf "\n%s\n" "${URL}"
-            until [ -n "${AUTHORIZATION_CODE}" ] && [ -n "${AUTHORIZATION_CODE_VALID}" ]; do
-                [ -n "${AUTHORIZATION_CODE}" ] && {
-                    if printf "%s\n" "${AUTHORIZATION_CODE}" | grep -qE "${AUTHORIZATION_CODE_REGEX}"; then
-                        AUTHORIZATION_CODE_VALID="true" && continue
-                    else
-                        "${QUIET:-_print_center}" "normal" " Invalid CODE given, try again.. " "-" && unset AUTHORIZATION_CODE authorization_code
-                    fi
-                }
-                { [ -z "${authorization_code}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter the authorization code " "-"; } || _clear_line 1
-                printf -- "-> "
-                read -r AUTHORIZATION_CODE && authorization_code=1
-            done
-            RESPONSE="$(curl --compressed "${CURL_PROGRESS}" -X POST \
-                --data "code=${AUTHORIZATION_CODE}&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&redirect_uri=${REDIRECT_URI}&grant_type=authorization_code" "${TOKEN_URL}")" || :
-            _clear_line 1 1>&2
+            printf "\n" && "${QUIET:-_print_center}" "normal" "If you have a refresh token generated, then type the token, else leave blank and press return key.." " "
+            printf "\n" && "${QUIET:-_print_center}" "normal" " Refresh Token " "-" && printf -- "-> "
+            read -r REFRESH_TOKEN
+            if [ -n "${REFRESH_TOKEN}" ]; then
+                "${QUIET:-_print_center}" "normal" " Checking refresh token.. " "-"
+                if ! printf "%s\n" "${REFRESH_TOKEN}" | grep -qE "${REFRESH_TOKEN_REGEX}"; then
+                    { _get_access_token_and_update normal && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || check_error=1
+                else
+                    check_error=true
+                fi
+                [ -n "${check_error}" ] && "${QUIET:-_print_center}" "normal" " Error: Invalid Refresh token given, follow below steps to generate.. " "-" && unset REFRESH_TOKEN
+            else
+                "${QUIET:-_print_center}" "normal" " No Refresh token given, follow below steps to generate.. " "-"
+            fi
 
-            REFRESH_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value refresh_token 1 1 || :)"
-            { _get_access_token_and_update "${RESPONSE}" && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || return 1
+            [ -z "${REFRESH_TOKEN}" ] && {
+                printf "\n" && "${QUIET:-_print_center}" "normal" "Visit the below URL, tap on allow and then enter the code obtained" " "
+                URL="https://accounts.google.com/o/oauth2/auth?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code&prompt=consent"
+                printf "\n%s\n" "${URL}"
+                until [ -n "${AUTHORIZATION_CODE}" ] && [ -n "${AUTHORIZATION_CODE_VALID}" ]; do
+                    [ -n "${AUTHORIZATION_CODE}" ] && {
+                        if printf "%s\n" "${AUTHORIZATION_CODE}" | grep -qE "${AUTHORIZATION_CODE_REGEX}"; then
+                            AUTHORIZATION_CODE_VALID="true" && continue
+                        else
+                            "${QUIET:-_print_center}" "normal" " Invalid CODE given, try again.. " "-" && unset AUTHORIZATION_CODE authorization_code
+                        fi
+                    }
+                    { [ -z "${authorization_code}" ] && printf "\n" && "${QUIET:-_print_center}" "normal" " Enter the authorization code " "-"; } || _clear_line 1
+                    printf -- "-> "
+                    read -r AUTHORIZATION_CODE && authorization_code=1
+                done
+                RESPONSE="$(curl --compressed "${CURL_PROGRESS}" -X POST \
+                    --data "code=${AUTHORIZATION_CODE}&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&redirect_uri=${REDIRECT_URI}&grant_type=authorization_code" "${TOKEN_URL}")" || :
+                _clear_line 1 1>&2
+
+                REFRESH_TOKEN="$(printf "%s\n" "${RESPONSE}" | _json_value refresh_token 1 1 || :)"
+                { _get_access_token_and_update normal "${RESPONSE}" && _update_config REFRESH_TOKEN "${REFRESH_TOKEN}" "${CONFIG}"; } || return 1
+            }
+            printf "\n"
         }
-        printf "\n"
-    }
 
-    { [ -z "${ACCESS_TOKEN}" ] || ! printf "%s\n" "${ACCESS_TOKEN}" | grep -qE "${ACCESS_TOKEN_REGEX}" || [ "${ACCESS_TOKEN_EXPIRY:-0}" -lt "$(date +'%s')" ]; } &&
-        { _get_access_token_and_update || return 1; }
-    printf "%b\n" "ACCESS_TOKEN=\"${ACCESS_TOKEN}\"\nACCESS_TOKEN_EXPIRY=\"${ACCESS_TOKEN_EXPIRY}\"" >| "${TMPFILE}_ACCESS_TOKEN"
+        { [ -z "${ACCESS_TOKEN}" ] || ! printf "%s\n" "${ACCESS_TOKEN}" | grep -qE "${ACCESS_TOKEN_REGEX}" || [ "${ACCESS_TOKEN_EXPIRY:-0}" -lt "$(date +'%s')" ]; } &&
+            { _get_access_token_and_update normal || return 1; }
+        printf "%b\n" "ACCESS_TOKEN=\"${ACCESS_TOKEN}\"\nACCESS_TOKEN_EXPIRY=\"${ACCESS_TOKEN_EXPIRY}\"" >| "${TMPFILE}_ACCESS_TOKEN"
+    else
+        command -v openssl 2>| /dev/null 1>&2 ||
+            { "${QUIET:-_print_center}" 'normal' "Error: openssl not installed, install openssl to use '-sa | --service-account' flag." "=" 1>&2 && return 1; }
+
+        SERVICE_ACCOUNT="SA_$(_json_value private_key_id 1 1 < "${SERVICE_ACCOUNT_FILE}")_SA" ||
+            { "${QUIET:-_print_center}" 'normal' "Error: Invalid service account file." "=" 1>&2 && return 1; }
+
+        SERVICE_ACCOUNT_ACCESS_TOKEN="$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN"\")"
+        SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY="$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN_EXPIRY"\")"
+
+        { [ -z "${SERVICE_ACCOUNT_ACCESS_TOKEN}" ] || ! printf "%s\n" "${SERVICE_ACCOUNT_ACCESS_TOKEN}" | grep -qE "${ACCESS_TOKEN_REGEX}" || [ "${SERVICE_ACCOUNT_ACCESS_TOKEN_EXPIRY:-0}" -lt "$(date +'%s')" ]; } && {
+            ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || { printf "%s\n" "${ASSERTION_DATA}" 1>&2 && return 1; }
+            _get_access_token_and_update sa "${ASSERTION_DATA}" || return 1
+        }
+
+        printf "%s\n%s\n" "ACCESS_TOKEN=\"$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN"\")"\" \
+            "ACCESS_TOKEN_EXPIRY=\"$(eval printf "%s" \"\$"${SERVICE_ACCOUNT}_ACCESS_TOKEN_EXPIRY"\")"\" >| "${TMPFILE}_ACCESS_TOKEN"
+    fi
 
     # launch a background service to check access token and update it
     # checks ACCESS_TOKEN_EXPIRY, try to update before 5 mins of expiry, a fresh token gets 60 mins
     # process will be killed when script exits or "${MAIN_PID}" is killed
     {
         until ! kill -0 "${MAIN_PID}" 2>| /dev/null 1>&2; do
+            unset ASSERTION_DATA MODE
             . "${TMPFILE}_ACCESS_TOKEN"
             CURRENT_TIME="$(date +'%s')"
             REMAINING_TOKEN_TIME="$((CURRENT_TIME - ACCESS_TOKEN_EXPIRY))"
             if [ "${REMAINING_TOKEN_TIME}" -le 300 ]; then
+                [ -n "${SERVICE_ACCOUNT_FILE}" ] && {
+                    ASSERTION_DATA="$(_generate_jwt "${SERVICE_ACCOUNT_FILE}" "${SCOPE}")" || :
+                    MODE="sa"
+                }
                 # timeout after 30 seconds, it shouldn't take too long anyway, and update tmp config
-                CONFIG="${TMPFILE}_ACCESS_TOKEN" _timeout 30 _get_access_token_and_update || :
+                SERVICE_ACCOUNT="" CONFIG="${TMPFILE}_ACCESS_TOKEN" _timeout 30 _get_access_token_and_update "${MODE:-normal}" "${ASSERTION_DATA:-}" || :
             else
                 TOKEN_PROCESS_TIME_TO_SLEEP="$(if [ "${REMAINING_TOKEN_TIME}" -le 301 ]; then
                     printf "0\n"
@@ -422,7 +454,7 @@ _check_credentials() {
             fi
             sleep 1
         done
-    } &
+    } 2>| /dev/null 1>&2 &
     ACCESS_TOKEN_SERVICE_PID="${!}"
 
     return 0
@@ -710,8 +742,8 @@ main() {
             [ -f "${TMPFILE}_ACCESS_TOKEN" ] && {
                 . "${TMPFILE}_ACCESS_TOKEN"
                 [ "${INITIAL_ACCESS_TOKEN}" = "${ACCESS_TOKEN}" ] || {
-                    _update_config ACCESS_TOKEN "${ACCESS_TOKEN}" "${CONFIG}"
-                    _update_config ACCESS_TOKEN_EXPIRY "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
+                    _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN" "${ACCESS_TOKEN}" "${CONFIG}"
+                    _update_config "${SERVICE_ACCOUNT:+${SERVICE_ACCOUNT}_}ACCESS_TOKEN_EXPIRY" "${ACCESS_TOKEN_EXPIRY}" "${CONFIG}"
                 }
             } 1>| /dev/null
 

--- a/sh/upload.sh
+++ b/sh/upload.sh
@@ -88,9 +88,9 @@ _cleanup_config() {
 $(grep -F ACCESS_TOKEN_EXPIRY "${config}" || :)
 EOF
 
-    chmod +w "${config}" &&
+    chmod u+w "${config}" &&
         printf "%s\n" "$(grep -Ev "^\$${values_regex:+|${values_regex}}" "${config}")" >| "${config}" &&
-        chmod -w "${config}"
+        chmod "a-w-r-x,u+r" "${config}"
     return 0
 }
 


### PR DESCRIPTION
when a service_account file is specified, the access_token obtained must be put in the temporary file so as not to use the initial validation step "first run"
<img width="1409" alt="Captura de Pantalla 2020-12-30 a la(s) 16 46 41" src="https://user-images.githubusercontent.com/4097850/103382916-d9029980-4abe-11eb-82a9-a684faacc20e.png">
